### PR TITLE
Fix the command for creating superuser in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Notice how two services are created: `db_1` and `web_1`. See that migrations run
 
 In a new tab, run: 
 
-    docker-compose run web ./manage.py createsuperuser 
+    docker-compose run web --rm ./manage.py createsuperuser
 
 ## Create sample data 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Notice how two services are created: `db_1` and `web_1`. See that migrations run
 
 In a new tab, run: 
 
-    docker-compose run web --manage.py createsuperuser 
+    docker-compose run web ./manage.py createsuperuser 
 
 ## Create sample data 
 


### PR DESCRIPTION
There was a typo in the README for the command that creates a super user.